### PR TITLE
Bug fix for script so it correctly blocks

### DIFF
--- a/bin/stream-all-maxfile
+++ b/bin/stream-all-maxfile
@@ -19,7 +19,7 @@ for u in $RXUUTS; do
 	fi
 	echo "pid $u $!"
 done
-for u in $UUTS; do
+for u in $RXUUTS; do
 	wait
 	ls -l $u.dat
 done


### PR DESCRIPTION
Typo in final loop variable was causing script to immediately finish and echo done whilst backgrounding the streams.

Job still got done in the end but printouts were misleading.